### PR TITLE
generate utf8 passwords

### DIFF
--- a/encryption/crypto.go
+++ b/encryption/crypto.go
@@ -1,6 +1,7 @@
 package encryption
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
@@ -152,20 +153,20 @@ func DefaultPasswordCharRange() []uint8 {
 
 // GeneratePassword generates a random sequence of the given ASCII characters.
 func GeneratePassword(length int, characters []uint8) string {
+	var buffer bytes.Buffer
 	maxIndex := len(characters)
 	if maxIndex < 2 {
 		panic("At least 2 characters must be provided")
 	}
 	maxIndexBig := big.NewInt(int64(maxIndex))
-	result := make([]uint8, length)
 	for i := 0; i < length; i++ {
 		n, err := rand.Int(rand.Reader, maxIndexBig)
 		if err != nil {
 			panic(err)
 		}
-		result[i] = characters[int(n.Uint64())]
+		buffer.WriteString(string(characters[int(n.Uint64())]))
 	}
-	return string(result)
+	return buffer.String()
 }
 
 // PasswordHash creates a cryptographical hash of the salted password.

--- a/encryption/crypto_test.go
+++ b/encryption/crypto_test.go
@@ -261,9 +261,8 @@ func TestGeneratePassword(t *testing.T) {
 		// generate 1000 passwords
 		for i := 0; i < n; i++ {
 			pass := GeneratePassword(passLength, characterRange)
-			require.Len(t, pass, passLength, "Generated Password does not have the correct length")
-			if len(pass) != utf8.RuneCountInString(pass) {
-				t.Errorf("generated password rune count != byte count")
+			if utf8.RuneCountInString(pass) != passLength {
+				t.Errorf("generated password rune count: %d (expected %d)", utf8.RuneCountInString(pass), passLength)
 			}
 			if !utf8.ValidString(pass) {
 				t.Errorf("generated password is not a valid utf8 string: %s", pass)
@@ -271,13 +270,13 @@ func TestGeneratePassword(t *testing.T) {
 
 			// verify all characters are within the range
 		charLoop:
-			for _, c := range []byte(pass) {
-				for _, r := range characterRange {
-					if r == c {
+			for _, rune := range pass {
+				for _, char := range characterRange {
+					if string(char) == string(rune) {
 						continue charLoop
 					}
 				}
-				t.Error("unexpected byte in generated password: ", c)
+				t.Error("unexpected rune in generated password: ", rune)
 			}
 			passwordSet[pass] = true
 		}


### PR DESCRIPTION
The generated passwords in my environment (fedora) were mangled.  I suspect a problem in all environments.  This could easily go unnoticed because you rarely see the password written out.

This patch includes a test to catch the error, and changes GeneratePassword to make utf8 strings (i.e. with 16 runes, rather than 16 bytes).
